### PR TITLE
Include all regions - not just North American ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This workshop can be deployed in any AWS region that supports the following serv
 - Amazon S3
 - Amazon DynamoDB
 
-You can refer to the [region table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) in the AWS documentation to see which regions have the supported services. Among the supported regions you can choose are: **N. Virginia, Ohio, Oregon**.
+You can refer to the [region table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) in the AWS documentation to see which regions have the supported services. Among the currently supported regions you can choose are: **N. Virginia, Ohio, Oregon, Ireland, Frankfurt, Singapore, Tokyo, Sydney, and Mumbai**.
 
 Once you've chosen a region, you should deploy all of the resources for this workshop there. Make sure you select your region from the dropdown in the upper right corner of the AWS Console before getting started.
 


### PR DESCRIPTION

*Issue #, if available:    1

*Description of changes:*
The original list only included regions in North America.  I've checked the region table and - for the list of services - this is all the regions.  What's unclear, is whether Cloud 9 should be included in the list?  If that's the case, only Ireland and Singapore should be added.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
